### PR TITLE
SSL support for Home-Assistant API connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ python3 -m pip install Twisted
 python3 -m pip install autobahn[twisted]
 ```
 
+### Install optional dependencies
+For connecting via SSL
+```
+python3 -m pip install pyOpenSSL
+```
+
 ### Configure Kivy
 Edit file `/home/pi/.kivy/config.ini`
 


### PR DESCRIPTION
Needed SSL Support to connect to my "SSL only" home assistant installation. So here it is :)
Im not that sure about the changes/format in README.md but if you enable SSL you have to have pyOpenSSL installed.
